### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# Shopware platform editor configuration normalization
+# http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.ini]
+insert_final_newline = false


### PR DESCRIPTION
This PR adds a `.editorconfig` file. Its contents were copied from [`shopware/platform`](https://github.com/VIISON/shopware-platform/blob/c178d6a606bc8cabed6906e50250b8ea91cf1b80/.editorconfig).