### PR TITLE
Added command to log onto the docker container as root

### DIFF
--- a/dev-ops/docker/actions/ssh-root.sh
+++ b/dev-ops/docker/actions/ssh-root.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+TTY: docker exec -i --env COLUMNS=`tput cols` --env LINES=`tput lines` -u 0 -t __APP_ID__ bash


### PR DESCRIPTION
With this action you can also log into the container using `./psh.phar docker:ssh-root` and be logged in as root. This is useful for tests on installing software without rebuilding the container everytime.