### PR TITLE
Add require php to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         }
     },
     "require": {
+        "php": "~7.2",
         "ocramius/package-versions": "1.4.0",
         "shopware/platform": "dev-master"
     },


### PR DESCRIPTION
Without this declaration, some IDE's are warning about language features not available in previous versions. As Shopware 6 will have a minimum of PHP7.1, adding this dependency to composer.json does make sense.