### PR TITLE
Fix .gitignore & Enable custom plugins in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,26 +9,17 @@
 /docker-compose.override.yml
 
 /config/jwt/*
-!/config/jwt/.gitkeep
 
-/custom/*
+/custom/plugins/*
 
 /build/*
-!/build/artifacts/.gitkeep
-!/build/media/.gitkeep
 
 /public/fonts/*
-!/public/fonts/.gitkeep
 /public/img/*
-!/public/img/.gitkeep
 /public/css/*
-!/public/css/.gitkeep
 /public/js/*
-!/public/js/.gitkeep
 /public/media/*
-!/public/media/.gitkeep
 /public/thumbnail/*
-!/public/thumbnail/.gitkeep
 /public/plugins/*
 /public/assets/*
 
@@ -40,7 +31,6 @@
 /dev-ops/analyze/vendor-bin/**/vendor
 /dev-ops/analyze/.jscpd
 /dev-ops/analyze/tmp
-!/dev-ops/analyze/tmp/**/.gitkeep
 
 /selenium-debug.log
 chromedriver.log
@@ -60,3 +50,5 @@ chromedriver.log
 ###> phpunit/phpunit ###
 /phpunit.xml
 ###< phpunit/phpunit ###
+
+!.gitkeep


### PR DESCRIPTION
This change enables shop owners, to add own plugins to their
repositories. Git does not allow to renable a sub path, from an already
disabled path. So this does not work:

/custom/*
!/custom/.gitkeep
!/custom/plugins/MyOwnPlugin

To enable adding own plugins to the repository, I changed the following
line:

`/custom/*`

to

`/custom/plugins/*`

Additionally I removed all superflous `!.gitkeep` statement and added a
global one at the end of the .gitignore.