### PR TITLE
Fix Kernel constructor arguments

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,6 @@
 <?php declare(strict_types=1);
 
 use PackageVersions\Versions;
-use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
 use Shopware\Development\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;

--- a/bin/console
+++ b/bin/console
@@ -38,7 +38,6 @@ if ($debug) {
 $shopwareVersion = Versions::getVersion('shopware/platform');
 
 $connection = Kernel::getConnection();
-$pluginLoader = new DbalKernelPluginLoader($classLoader, null, $connection);
-$kernel = new Kernel($env, $debug, $pluginLoader, $shopwareVersion, $connection);
+$kernel = new Kernel($env, $debug, $classLoader, $shopwareVersion, $connection);
 $application = new Application($kernel);
 $application->run($input);

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace Shopware\Development;
 
+use Composer\Autoload\ClassLoader;
 use Doctrine\DBAL\Connection;
-use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
 
 class Kernel extends \Shopware\Core\Kernel
 {
     public function __construct(
         string $environment,
         bool $debug,
-        KernelPluginLoader $pluginLoader,
+        ClassLoader $classLoader,
         ?string $version = null,
         ?Connection $connection = null
     ) {
-        parent::__construct($environment, $debug, $pluginLoader, $version);
+        parent::__construct($environment, $debug, $classLoader, $version);
 
         self::$connection = $connection;
         if (!$connection) {


### PR DESCRIPTION
Since the constructor arguments of `\Shopware\Core\Kernel` have changed, they also need to be adapted for everyone extending from it.
Also `bin/console` calls it the "old" way. See [NEXT-5125](https://issues.shopware.com/issues/NEXT-5125).