### PR TITLE
xdebug in docker

### DIFF
--- a/dev-ops/docker/containers/app/Dockerfile
+++ b/dev-ops/docker/containers/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM webdevops/php-apache:7.2
+FROM webdevops/php-apache-dev:7.2
 
 COPY wait-for-it.sh /usr/local/bin/
 


### PR DESCRIPTION
In development you want to have xdebug, therefore the container 
should be based on the `-dev` image.