### PR TITLE
Update .gitlab-ci.yml to better support Kubernetes executor

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 variables:
     DOCKER_TLS_CERTDIR: "/certs"
+    DOCKER_HOST: tcp://localhost:2376
     IMAGE_TAG: shopware/development
 
 .base:


### PR DESCRIPTION
Build in Gitlab will fail, when you use the Kubernetes executor. 
`DOCKER_DRIVER: overlay` could also help preventing Error depending on the default storage-driver used.

From https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#tls-enabled:

> When using dind service, we need to instruct docker, to talk with
the daemon started inside of the service. The daemon is available
with a network connection instead of the default
/var/run/docker.sock socket. docker:19.03.1 does this automatically
by setting the DOCKER_HOST in
https://github.com/docker-library/docker/blob/d45051476babc297257df490d22cbd806f1b11e4/19.03.1/docker-entrypoint.sh#L23-L29
    #
The 'docker' hostname is the alias of the service container as described at
https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#accessing-the-services.
    #
Note that if you're using the Kubernetes executor, the variable
should be set to tcp://localhost:2376 because of how the
Kubernetes executor connects services to the job container
DOCKER_HOST: tcp://localhost:2376