### PR TITLE
Add environment option to disable plugin loader

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,6 +3,7 @@
 
 use PackageVersions\Versions;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
+use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Development\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -26,6 +27,7 @@ if (!class_exists(Dotenv::class)) {
 $input = new ArgvInput();
 $env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
 $debug = (bool) ($_SERVER['APP_DEBUG'] ?? ($env !== 'prod')) && !$input->hasParameterOption('--no-debug', true);
+$withoutPlugins = (bool) ($_SERVER['APP_NO_PLUGINS'] ?? '0');
 
 if ($debug) {
     umask(0000);
@@ -50,7 +52,7 @@ $connection = Kernel::getConnection();
 $cacheId = (new CacheIdLoader($connection))
     ->load();
 
-$pluginLoader = new DbalKernelPluginLoader($classLoader, null, $connection);
+$pluginLoader = $withoutPlugins ? new StaticKernelPluginLoader($classLoader) : new DbalKernelPluginLoader($classLoader, null, $connection);
 $kernel = new Kernel($env, $debug, $pluginLoader, $cacheId, $shopwareVersion, $connection);
 $application = new Application($kernel);
 $application->run($input);


### PR DESCRIPTION
In case of rewriting the composer.json of a plugin by e.g. moving code and adding a PSR-4 entry the services.\[x|y\]ml is still loaded and fails due to unfindable code. To fix that one has to refresh the plugin data on the database to move the new autoload to the database. But the application fails to run as it can't boot the dependency container. To bypass this one can simply disable plugin loading once. I added an easy way to change the plugin loader:
Old: `bin/console plugin:refresh`
New: `APP_NO_PLUGINS=1 bin/console plugin:refresh`