### PR TITLE
Unignore gitkeeps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,12 @@
 /config/packages/local.yaml
 /config/packages/local.yml
 
-/custom/*
+/custom/plugins/**
+!/custom/plugins/.gitkeep
 
-/build/*
+/build/artifacts/**
 !/build/artifacts/.gitkeep
+/build/media/**
 !/build/media/.gitkeep
 
 /public/fonts/*


### PR DESCRIPTION
Before this change, some .gitkeep files in this repository were not ignored only because they had previously been added. The gitignore rules would prevent them from being added anew.

This change exempts some .gitkeep files from ever being ignored.

I assume this change reflects the intended effect of the previous versions of this repository's `.gitignore`.

Verification:

On master, the relevant `.gitkeep` files are effectively ignored, not because they appear in `.gitignore`, but because they have previously been added:

```shell
$ git checkout master
$ git check-ignore --verbose --non-matching custom/plugins/non-existent custom/plugins/.gitkeep build/media/non-existent build/media/.gitkeep build/artifacts/non-existent build/artifacts/.gitkeep
.gitignore:14:/custom/*	custom/plugins/non-existent
::	custom/plugins/.gitkeep
.gitignore:16:/build/*	build/media/non-existent
::	build/media/.gitkeep
.gitignore:16:/build/*	build/artifacts/non-existent
.gitignore:16:/build/*	build/artifacts/.gitkeep
```

On master (as of 4bad8cc39f0448a308e712e8817f625a8c00bbf1), `.gitignore` prevents some `.gitkeep` files from being tracked (if they had not been previously added):

```shell
$ git checkout master
# […]
$ git --git-dir .git.test init
# […]
$ git --work-tree=. --git-dir .git.test check-ignore --verbose --non-matching custom/plugins/non-existent custom/plugins/.gitkeep build/media/non-existent build/media/.gitkeep build/artifacts/non-existent build/artifacts/.gitkeep 
.gitignore:14:/custom/*	custom/plugins/non-existent
.gitignore:14:/custom/*	custom/plugins/.gitkeep
.gitignore:16:/build/*	build/media/non-existent
.gitignore:16:/build/*	build/media/.gitkeep
.gitignore:16:/build/*	build/artifacts/non-existent
.gitignore:16:/build/*	build/artifacts/.gitkeep
$ rm -r .git.test
```

Above, the `.gitkeep` files are now considered ignored.

This PR's change makes them no longer be ignored:

```shell
$ git checkout pickware/unignore-gitkeeps
# […]
$ git --git-dir .git.test init
# […]
$ git --work-tree=. --git-dir .git.test check-ignore --verbose --non-matching custom/plugins/non-existent custom/plugins/.gitkeep build/media/non-existent build/media/.gitkeep build/artifacts/non-existent build/artifacts/.gitkeep
.gitignore:14:/custom/plugins/**	custom/plugins/non-existent
.gitignore:15:!/custom/plugins/.gitkeep	custom/plugins/.gitkeep
.gitignore:19:/build/media/**	build/media/non-existent
.gitignore:20:!/build/media/.gitkeep	build/media/.gitkeep
.gitignore:17:/build/artifacts/**	build/artifacts/non-existent
.gitignore:18:!/build/artifacts/.gitkeep	build/artifacts/.gitkeep
$ rm -r .git.test
```

Above, the `.gitkeep` files are now no longer ignored (note the negations starting with `!`).

The relevant documentation to explain this difference in behavior is in the [manual page for `gitignore` (`man gitignore`)](https://github.com/git/git/blob/b4374e96c84ed9394fed363973eb540da308ed4f/Documentation/gitignore.txt#L85-L86):

> It is not possible to re-include a file if a parent directory of that file is excluded.