### PR TITLE
Increase sort_buffer_size

### DIFF
--- a/dev-ops/docker/containers/mysql/dev.cnf
+++ b/dev-ops/docker/containers/mysql/dev.cnf
@@ -7,6 +7,7 @@ innodb_log_buffer_size = 64M
 innodb_log_file_size = 512M
 innodb_flush_method = O_DIRECT
 innodb_doublewrite = 0
+sort_buffer_size = 2G
 
 max_connections=10000
 group_concat_max_len=320000


### PR DESCRIPTION
When working with more complex custom fields sets (i.e. when migrating from other shop systems) the sort_buffer_size quickly reach its limit. Therefore I suggest increasing the sort_buffer_size by default.