### PR TITLE
Change behaviour of ./psh.phar docker:stop using docker-compose stop instead of down

### DIFF
--- a/.psh.yaml.dist
+++ b/.psh.yaml.dist
@@ -48,6 +48,7 @@ const:
   DEVPORT: "8080"
   STOREFRONT_PROXY_PORT: 9998
   VERSION:
+  DOCKER_STOP_BEHAVIOUR: down
 
 dynamic:
   USERKEY: echo "$(id -u):$(id -g)"

--- a/dev-ops/docker/actions/stop.sh
+++ b/dev-ops/docker/actions/stop.sh
@@ -3,4 +3,4 @@
 # Stop docker-sync
 if [ -n "__DOCKER_SYNC_ENABLED__" ]; then docker-sync stop; fi
 
-docker-compose down
+docker-compose stop

--- a/dev-ops/docker/actions/stop.sh
+++ b/dev-ops/docker/actions/stop.sh
@@ -3,4 +3,4 @@
 # Stop docker-sync
 if [ -n "__DOCKER_SYNC_ENABLED__" ]; then docker-sync stop; fi
 
-docker-compose stop
+docker-compose __DOCKER_STOP_BEHAVIOUR__


### PR DESCRIPTION
Currently when you call `./psh.phar docker:stop` it ultimately calls `docker-compose down`. The [down](https://docs.docker.com/compose/reference/down/) command removes all the containers and networks used. This has two side effects:

1. when using docker maintenance commands like `docker volume prune` or  `docker image prune` the volumes and images related to the project are lost. It happened to me to lose my development database because of this
2. the `start` command is slower, having to recreate the containers (hopefully from existing images, but in case of a `prune` the images will be re-built)