### PR TITLE
Configurable docker image and php version

### DIFF
--- a/.psh.yaml.dist
+++ b/.psh.yaml.dist
@@ -48,6 +48,8 @@ const:
   DEVPORT: "8080"
   STOREFRONT_PROXY_PORT: 9998
   VERSION:
+  DOCKER_IMAGE_VARIANT: webdevops/php-apache
+  DOCKER_PHP_VERSION: 7.2
 
 dynamic:
   USERKEY: echo "$(id -u):$(id -g)"

--- a/dev-ops/docker/containers/app/Dockerfile
+++ b/dev-ops/docker/containers/app/Dockerfile
@@ -1,4 +1,6 @@
-FROM webdevops/php-apache:7.2
+ARG IMAGE_VARIANT
+ARG PHP_VERSION
+FROM ${IMAGE_VARIANT}:${PHP_VERSION}
 
 COPY wait-for-it.sh /usr/local/bin/
 

--- a/dev-ops/docker/docker-compose.override.yml
+++ b/dev-ops/docker/docker-compose.override.yml
@@ -9,6 +9,9 @@ services:
       args:
         USER_ID: __USER_ID__
         GROUP_ID: __GROUP_ID__
+        IMAGE_VARIANT: __DOCKER_IMAGE_VARIANT__
+        PHP_VERSION: __DOCKER_PHP_VERSION__
+
     volumes:
       - __DOCKER_APP_VOLUME_MOUNT__
       - ~/.npm:/.npm


### PR DESCRIPTION
With this PR the image used by docker-compose is configurable by .psh.yaml. This allows to:

1. Change PHP version for development and testing purposes
2. Change the docker image used (e.g. to add xdebug support by changing it to `webdevops/php-apache-dev` instead of `webdevops/php-apache`)

without having to do changes to version controlled files.