### PR TITLE
Add support for bundled private composer dependencies via path repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,13 @@
         },
         {
             "type": "path",
+            "url": "custom/plugins/*/packages/*",
+            "options": {
+                "symlink": true
+            }
+        },
+        {
+            "type": "path",
             "url": "platform",
             "options": {
                 "symlink": true


### PR DESCRIPTION
Currently with the upcoming changes in Shopware v6.4.0.0 which will allow to mark a plugin as composer plugin and thus let composer manage its dependencies (https://github.com/shopware/platform/commit/59d90d70f177e204ba606905a80417f60ad5e515), there is a need to also support private dependencies which you bundle with the plugin.
This PR enables the usage of private dependencies through a path repo `packages` within each plugin directory.