### PR TITLE
Add support to mock the filesystem in integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "johnkary/phpunit-speedtrap": "3.1.0",
         "league/flysystem-memory": "1.0.2",
         "mbezhanov/faker-provider-collection": "1.2.1",
+        "mikey179/vfsstream": "^1.6",
         "nikic/php-parser": "4.3.0",
         "opis/json-schema": "1.0.19",
         "phpunit/phpunit": "8.5.2",


### PR DESCRIPTION
The Shopware administration is unable to load a bundle's resources (CSS & JS) if the bundle's name contains bundle. In order to write an integration test for this case, you need to mock the file access of php's internal functions such as `file_exists`. The `mikey179/vfsstream` package allows you to do just that (For usage see: https://github.com/shopware/platform/pull/1607).

The package needs to be added to the development template since the `platform`'s shopware installation does not install the development dependencies of the platform repository.

This pr adds the package here so that the integration tests in the `https://github.com/shopware/platform` repository can mock the internal filesystem.