### PR TITLE
NEXT-10849 - Add selection of a default language when installing Shpware using the cli

### DIFF
--- a/.psh.yaml.dist
+++ b/.psh.yaml.dist
@@ -27,6 +27,7 @@ const:
   APP_ENV: "dev"
   APP_MAILER_URL: "smtp://mailhog:1025"
   APP_WATCH: "false"
+  APP_LANG: "en-GB"
   SSH_PRIVATE_KEY_PATH: ""
   ESLINT_DISABLE: "true"
   CYPRESS_HEADLESS: "true"

--- a/bin/setup
+++ b/bin/setup
@@ -79,6 +79,8 @@ use Symfony\Component\Process\Process;
             return $value;
         });
 
+        $configuration['APP_LANG'] = $io->ask('Default lang', 'en-GB');
+
         $configuration['BLUE_GREEN_DEPLOYMENT'] = $io->ask('Do you want to run blue/green deployment?', 'yes', function ($value) {
             $value = strtolower($value);
 

--- a/dev-ops/common/actions/init-shopware.sh
+++ b/dev-ops/common/actions/init-shopware.sh
@@ -6,6 +6,8 @@ INCLUDE: ./cache.sh
 bin/console database:migrate --all core
 bin/console database:migrate-destructive --all core --version-selection-mode=all
 
+bin/console language:change-default '__APP_LANG__'
+
 bin/console dal:refresh:index
 
 bin/console scheduled-task:register


### PR DESCRIPTION
 fixes shopware/platform#1864

1. Why is this change necessary?
Currently the only way to change the system default language is by the install GUI.

2. What does this change do, exactly?
add a console command to change the system default language

3. Describe each step to reproduce the issue or behaviour.
try to configure the system default language , via cli.

4. Please link to the relevant issues (if any).